### PR TITLE
Saving on Logarithmic Timescale

### DIFF
--- a/Example/example_berthier.jl
+++ b/Example/example_berthier.jl
@@ -31,7 +31,6 @@ max_MC_displacement = 0.1       # Maximal displacement in a displacement step in
 N_MD_equilibration_steps = 10^3   # Number of steps for short-time MD equilibration
 
 
-
 random_seed = rand(1:10^9)      # Seed for the random number generator
 box_size = (N / ρ)^(1 / dims)          # Cubic box dimension
 simulation_folder = "Data"      # Name of folder in which to store datafile
@@ -43,15 +42,26 @@ simulation_name_full = simulation_name * simulation_suffix     # Name of the dat
 skin_distanceMC = 0.6           # Size of the verlet cells for swap MC
 skin_distanceMD = 0.4          # Size of the verlet cells for MD
 
+# For dump info
+save_r = true
+save_v = true 
+save_F = true
+save_D = false
+save_Epot = false
+
+log_factor = 1.3
+N_starts = 100
+N_max = N_stepsMD
+
 dump_info = SimulationCode.DumpInfo(
     true, #save
     simulation_name_full,
-    0:1000:N_stepsMD,#SimulationCode.create_when_to_save_array(N_stepsMD, 200), #when save
-    true, #r
-    true, #v
-    true, #F
-    false, #D
-    false, #Epot      
+    SimulationCode.create_when_to_save_array(log_factor, N_starts, N_max), #when save
+    save_r, # r
+    save_v, # v
+    save_F, # F
+    save_D, # D
+    save_Epot, # Epot      
 )
 
 cb(x...) = nothing

--- a/src/Dump.jl
+++ b/src/Dump.jl
@@ -1,40 +1,35 @@
 """
-    create_when_to_save_array(maxsteps, doublefactor)
+    create_when_to_save_array(log_factor, N_starts, N_max)
 
-Creates an array of steps at which data should be saved during a simulation.
-
-This function generates an array of integers representing the steps at which 
-data should be saved. The intervals between these steps increase exponentially.
+Generates a sorted array of unique time indices at which data should be saved during a simulation.
 
 # Arguments
-- `maxsteps`: Maximum number of simulation steps.
-- `doublefactor`: Factor by which the interval (`dt`) between saves increases.
+- `log_factor::Float`: The multiplicative factor by which time intervals increase exponentially.
+- `N_starts::Int`: The number of starting points (offsets) from which to begin generating save times.
+- `N_max::Int`: The maximum time index (inclusive) up to which data will be saved.
 
 # Returns
-- `save_array`: Array of integers indicating the steps at which to save data.
+- `when_to_save::Vector{Int}`: A sorted vector of unique integer time indices less than or equal to `N_max`, indicating when to save data.
 
-# Details
-- The function starts with a step interval (`dt`) of 1 and doubles the interval 
-  after `doublefactor` steps.
-- This array helps in saving data more frequently at the beginning and less 
-  frequently as the simulation progresses, which is useful for capturing early 
-  dynamics in detail while reducing the amount of saved data for later steps.
-
+# Description
+This function creates a series of time indices for saving data in a simulation, starting from multiple initial offsets and increasing exponentially based on the `log_factor`. The save times are designed to be more frequent at the beginning and become less frequent over time.
 """
-function create_when_to_save_array(maxsteps, doublefactor)
-    save_array = Int64[]
-    t = 0
-    dt = 1
-    while t <= maxsteps
-        push!(save_array, t)
-        t += dt
-        if t == dt * doublefactor
-            dt *= 10
+
+function create_when_to_save_array(log_factor, N_starts, N_max)
+    start_times = 0:(N_max÷N_starts):N_max
+    when_to_save = Int[collect(start_times)...]
+    for i_start in start_times
+        t = 1
+        while t <= N_max
+            push!(when_to_save, t+i_start)
+            t *= log_factor
+            t = ceil(Int, t)
         end
     end
-    sort!(save_array)
-    return save_array
+    push!(when_to_save, N_max)
+    return sort(unique(when_to_save[when_to_save .<= N_max]))
 end
+
 
 """
     save_data(arrays, parameters::ParameterStruct{A,B}, output, neighborlist, restarted) where {A,B}

--- a/src/MC.jl
+++ b/src/MC.jl
@@ -190,6 +190,7 @@ function perform_swap_monte_carlo!(arrays, parameters, output, neighborlist)
     output.N_translations_total = 0
     output.N_translations_accepted = 0
     output.N_neighbor_list_rebuilds = 0
+    
     # when_to_save_array = create_when_to_save_array(parameters.N_steps, 50)
     prepare_savefile(parameters, arrays)
     arrays.r_old_array .= arrays.r_array


### PR DESCRIPTION
This pull request includes several changes aimed at improving the data saving mechanism and enhancing the configuration options in the `Example/example_berthier.jl` and `src/Dump.jl` files. The most important changes include updating the `create_when_to_save_array` function to use a logarithmic scale for data saving, and cleaning up unused code.

### Enhancements to Data Saving Mechanism:
* [`src/Dump.jl`](diffhunk://#diff-53fb91d9f083874afe8d246d5737849060e89f8d5bfea5412c238353ec1f169dL2-R33): Modified the `create_when_to_save_array` function to use a logarithmic factor for generating save times, allowing more control over the frequency of data saves. The function now takes `log_factor`, `N_starts`, and `N_max` as parameters.

### Enhanced Clarity of Example File:
* [`Example/example_berthier.jl`](diffhunk://#diff-d1ff773a62747f993ff4d214aace1b05eff686d7c01e69d6d40844a873205eceR45-R64): Added explicit names for variables in the example file to create instance of dump_info struct. : `save_r`, `save_v`, `save_F`, `save_D`, `save_Epot`, `log_factor`, `N_starts`, and `N_max`. 
